### PR TITLE
fix: use .selectorLabels in selectors

### DIFF
--- a/deployment/charts/cluster-connect-gateway/templates/deployment-controller.yaml
+++ b/deployment/charts/cluster-connect-gateway/templates/deployment-controller.yaml
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-      {{- include "cluster-connect-gateway.labels" . | nindent 6 }}
+      {{- include "cluster-connect-gateway.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.controller.replicaCount }}
   template:
     metadata:

--- a/deployment/charts/cluster-connect-gateway/templates/deployment-gateway.yaml
+++ b/deployment/charts/cluster-connect-gateway/templates/deployment-gateway.yaml
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: gateway
-      {{- include "cluster-connect-gateway.labels" . | nindent 6 }}
+      {{- include "cluster-connect-gateway.selectorLabels" . | nindent 6 }}
   replicas: {{ .Values.gateway.replicaCount }}
   template:
     metadata:

--- a/deployment/charts/cluster-connect-gateway/templates/service_metrics.yaml
+++ b/deployment/charts/cluster-connect-gateway/templates/service_metrics.yaml
@@ -18,5 +18,5 @@ spec:
     targetPort: metrics
   selector:
     app.kubernetes.io/component: controller
-    {{- include "cluster-connect-gateway.labels" . | nindent 4 -}}
+    {{- include "cluster-connect-gateway.selectorLabels" . | nindent 4 -}}
 {{- end -}}


### PR DESCRIPTION
### Description

The CCG Helm chart currently cannot be upgraded.  We see this message:

> error when patching "/dev/shm/2500439089": Deployment.apps "cluster-connect-gateway-gateway" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{"app.kubernetes.io/component":"gateway", "app.kubernetes.io/instance":"cluster-connect-gateway", "app.kubernetes.io/managed-by":"Helm", "app.kubernetes.io/name":"cluster-connect-gateway", "app.kubernetes.io/version":"1.1.0-dev-f075b087", "helm.sh/chart":"cluster-connect-gateway-1.1.0-dev"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable

The root cause is that the Helm chart is including selector labels that change per chart version.  We should be using the .selectorLabels here instead of .labels.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code