### PR TITLE
fix: remove unused parameter in pre-merge wf

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -119,6 +119,5 @@ jobs:
       run_test: false
       run_validate_clean_folder: false
       run_docker_build: true
-      run_scan_containers: false
       run_artifact: false
     secrets: inherit


### PR DESCRIPTION
### Description

The parameter was reoved from the pre-merge workflow in orch-ci https://github.com/open-edge-platform/orch-ci/commit/4ecba6bd86b92c842c88dec9e53cf782f523a746 and the CCG coresponding GHA WF was not updated, causing PRs to hang (https://github.com/open-edge-platform/cluster-connect-gateway/pull/26)

Fixes # (issue)

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

CI run during PR

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code