### PR TITLE
fix: remove post-merge invalid target

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -19,7 +19,6 @@ jobs:
       cache_go: true
       remove_cache_go: true
       run_build: true
-      run_security_scans: true
       run_version_check: true
       run_dep_version_check: true
       run_version_tag: true


### PR DESCRIPTION
### Description

This is to address issues like https://github.com/open-edge-platform/cluster-connect-gateway/actions/runs/14778663399

### Any Newly Introduced Dependencies

No

### How Has This Been Tested?

Post-merge CI should run when merged into main

### Checklist:

- [x ] I agree to use the APACHE-2.0 license for my code changes
- [x ] I have not introduced any 3rd party dependency changes
- [x ] I have performed a self-review of my code