### PR TITLE
Fixing cooldown issue in code scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gomod] "
+    cooldown:
+      default-days: 7
     groups:
       internal-dependencies:
         patterns:
@@ -33,6 +35,8 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[gha] "
+    cooldown:
+      default-days: 7
   - package-ecosystem: "docker"
     directory: "/"  # Changed from "directories" to "directory"
     schedule:
@@ -42,3 +46,5 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "[docker] "
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This pull request updates the Dependabot configuration to introduce a cooldown period for dependency update pull requests across multiple ecosystems. The cooldown helps limit how frequently new PRs are created for dependency updates, reducing noise and making it easier to manage updates.

Dependabot configuration changes:

* Added a `cooldown` section with `default-days: 7` for the `gomod`, `github-actions`, and `docker` package ecosystems in `.github/dependabot.yml`, ensuring that new update PRs are created at most once every 7 days for each dependency. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R16-R17) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R38-R39) [[3]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R49-R50)