### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that the `post-merge.yml` workflow will also run when a tag is pushed, in addition to the existing triggers.

- Added support for triggering the `post-merge.yml` workflow on any tag push by including a wildcard pattern under `tags` in the workflow's `on` section.-review of my code